### PR TITLE
Support inspecting bigints

### DIFF
--- a/src/inspect.js
+++ b/src/inspect.js
@@ -17,7 +17,7 @@ export function inspect(value, shallow, expand) {
     case "boolean":
     case "undefined": { value += ""; break; }
     case "number": { value = value === 0 && 1 / value < 0 ? "-0" : value + ""; break; }
-    case "bigint": { value = value + ""; break; }
+    case "bigint": { value = value + "n"; break; }
     case "string": { value = formatString(value, shallow === false); break; }
     case "symbol": { value = formatSymbol(value); break; }
     case "function": { return inspectFunction(value); }

--- a/src/inspect.js
+++ b/src/inspect.js
@@ -17,6 +17,7 @@ export function inspect(value, shallow, expand) {
     case "boolean":
     case "undefined": { value += ""; break; }
     case "number": { value = value === 0 && 1 / value < 0 ? "-0" : value + ""; break; }
+    case "bigint": { value = value + ""; break; }
     case "string": { value = formatString(value, shallow === false); break; }
     case "symbol": { value = formatSymbol(value); break; }
     case "function": { return inspectFunction(value); }

--- a/src/style.css
+++ b/src/style.css
@@ -58,6 +58,7 @@
 }
 
 .observablehq--number,
+.observablehq--bigint,
 .observablehq--date,
 .observablehq--regexp,
 .observablehq--symbol,


### PR DESCRIPTION
Fixes #5 

Notes:

- Unlike numbers, -0n is exactly the same value as 0n for bigints. ([ref](https://github.com/tc39/proposal-bigint/issues/29))

Todos:

- [x] Waiting on other changes to land in order to properly review & merge this one.
- [x] Should we format these with the `n`? I am suspecting: yes. It would be weird to print a bigint without it, and for an intrepid copy-paster to paste that into their notebook and get the wrong thing.