### PR TITLE
Use an SVG caret instead of UTF-8. Fixes #15

### DIFF
--- a/src/collapsed.js
+++ b/src/collapsed.js
@@ -36,7 +36,12 @@ export default function inspectCollapsed(object, shallow) {
   const span = document.createElement("span");
   span.className = "observablehq--collapsed";
   const a = span.appendChild(document.createElement("a"));
-  a.textContent = `▸${tag}${arrayish ? " [" : " {"}`;
+  const svg = a.appendChild(document.createElementNS("http://www.w3.org/2000/svg", "svg"));
+  svg.setAttribute("width", 16);
+  svg.setAttribute("height", 16);
+  svg.style.verticalAlign = "middle";
+  svg.innerHTML = "<path d='M12 8l-8 5V3z' fill='currentColor' />";
+  a.appendChild(document.createTextNode(`${tag}${arrayish ? " [" : " {"}`));
   span.addEventListener("mouseup", function(event) {
     event.stopPropagation();
     replace(span, inspectExpanded(object));

--- a/src/expanded.js
+++ b/src/expanded.js
@@ -26,7 +26,12 @@ export default function inspectExpanded(object) {
   const span = document.createElement("span");
   span.className = "observablehq--expanded";
   const a = span.appendChild(document.createElement("a"));
-  a.textContent = `▾${tag}${arrayish ? " [" : " {"}`;
+  const svg = a.appendChild(document.createElementNS("http://www.w3.org/2000/svg", "svg"));
+  svg.setAttribute("width", 16);
+  svg.setAttribute("height", 16);
+  svg.style.verticalAlign = "middle";
+  svg.innerHTML = "<path d='M8 12L3 4h10z' fill='currentColor' />";
+  a.appendChild(document.createTextNode(`${tag}${arrayish ? " [" : " {"}`));
   a.addEventListener("mouseup", function(event) {
     event.stopPropagation();
     replace(span, inspectCollapsed(object));

--- a/test/__snapshots__/inspector.test.js.snap
+++ b/test/__snapshots__/inspector.test.js.snap
@@ -1,79 +1,149 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Inspector .fulfilled(element) 1`] = `
-R {
-  "_node": <div
-    class="observablehq"
-  >
-    <span>
-      Surprise!
-    </span>
-  </div>,
-}
+<div
+  class="observablehq"
+>
+  <span>
+    Surprise!
+  </span>
+</div>
 `;
 
 exports[`Inspector .fulfilled(value) 1`] = `
-R {
-  "_node": <div
-    class="observablehq"
+<div
+  class="observablehq"
+>
+  <span
+    class="observablehq--collapsed observablehq--inspect"
   >
+    <a>
+      <svg
+        height="16"
+        style="vertical-align: middle;"
+        width="16"
+      >
+        <path
+          d="M12 8l-8 5V3z"
+          fill="currentColor"
+        />
+      </svg>
+      Array(3) [
+    </a>
     <span
-      class="observablehq--collapsed observablehq--inspect"
+      class="observablehq--number"
     >
-      <a>
-        ▸Array(3) [
-      </a>
+      1
+    </span>
+    , 
+    <span
+      class="observablehq--number"
+    >
+      2
+    </span>
+    , 
+    <span
+      class="observablehq--number"
+    >
+      3
+    </span>
+    ]
+  </span>
+</div>
+`;
+
+exports[`Inspector .fulfilled(value) 2`] = `
+<div
+  class="observablehq"
+>
+  <span
+    class="observablehq--expanded observablehq--inspect"
+  >
+    <a>
+      <svg
+        height="16"
+        style="vertical-align: middle;"
+        width="16"
+      >
+        <path
+          d="M8 12L3 4h10z"
+          fill="currentColor"
+        />
+      </svg>
+      Array(3) [
+    </a>
+    <div
+      class="observablehq--field"
+    >
+      <span
+        class="observablehq--index"
+      >
+          0
+      </span>
+      : 
       <span
         class="observablehq--number"
       >
         1
       </span>
-      , 
+    </div>
+    <div
+      class="observablehq--field"
+    >
+      <span
+        class="observablehq--index"
+      >
+          1
+      </span>
+      : 
       <span
         class="observablehq--number"
       >
         2
       </span>
-      , 
+    </div>
+    <div
+      class="observablehq--field"
+    >
+      <span
+        class="observablehq--index"
+      >
+          2
+      </span>
+      : 
       <span
         class="observablehq--number"
       >
         3
       </span>
-      ]
-    </span>
-  </div>,
-}
+    </div>
+    ]
+  </span>
+</div>
 `;
 
 exports[`Inspector .pending() 1`] = `
-R {
-  "_node": <div
-    class="observablehq observablehq--running"
-  />,
-}
+<div
+  class="observablehq observablehq--running"
+/>
 `;
 
 exports[`Inspector .rejected(Error) 1`] = `
-R {
-  "_node": <div
-    class="observablehq observablehq--error"
+<div
+  class="observablehq observablehq--error"
+>
+  <span
+    class="observablehq--inspect"
   >
-    <span
-      class="observablehq--inspect"
-    >
-      Error: Danger!
-    </span>
-  </div>,
-}
+    Error: Danger!
+  </span>
+</div>
 `;
 
 exports[`Inspector initial state 1`] = `
-R {
-  "_node": <div
-    class="observablehq"
-  />,
-}
+<div
+  class="observablehq"
+/>
 `;
 
 exports[`into into(div) 1`] = `

--- a/test/inspector.test.js
+++ b/test/inspector.test.js
@@ -2,36 +2,37 @@
 const { Inspector } = require("../dist/notebook-inspector.umd.js");
 
 describe("Inspector", () => {
-  let inspector;
+  let inspector, elem;
   beforeEach(() => {
-    const elem = document.createElement("div");
+    elem = document.createElement("div");
     inspector = new Inspector(elem);
   });
 
   test("initial state", () => {
-    expect(inspector).toMatchSnapshot();
+    expect(elem).toMatchSnapshot();
   });
 
   test(".pending()", () => {
     inspector.pending();
-    expect(inspector).toMatchSnapshot();
+    expect(elem).toMatchSnapshot();
   });
 
-  test(".fulfilled(element)", () => {
-    const span = document.createElement("span");
+  test(".fulfilled(element)", () => { const span = document.createElement("span");
     span.textContent = "Surprise!";
     inspector.fulfilled(span);
-    expect(inspector).toMatchSnapshot();
+    expect(elem).toMatchSnapshot();
   });
 
   test(".fulfilled(value)", () => {
     inspector.fulfilled([1, 2, 3]);
-    expect(inspector).toMatchSnapshot();
+    expect(elem).toMatchSnapshot();
+    elem.querySelector("a").dispatchEvent(new MouseEvent("mouseup"));
+    expect(elem).toMatchSnapshot();
   });
 
   test(".rejected(Error)", () => {
     inspector.rejected(new Error("Danger!"));
-    expect(inspector).toMatchSnapshot();
+    expect(elem).toMatchSnapshot();
   });
 });
 


### PR DESCRIPTION
Does what it says on the tin: instead of using UTF8 glyphs ▶ and ◀, inserts teeny tiny SVG graphics for the toggle, so that browsers with limited-coverage monospace system fonts don't get pwned.