### PR TITLE
Make caret smaller, simplify caret construction, add .js to imports

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,4 @@
 .esm-cache/
 dist/*.zip
 test/
+demo.html

--- a/demo.html
+++ b/demo.html
@@ -1,0 +1,149 @@
+<html>
+<link rel="stylesheet" href="https://unpkg.com/tachyons@4.10.0/css/tachyons.min.css"/>
+<style>
+:root {
+  --syntax_normal: #1b1e23;
+  --syntax_comment: #a9b0bc;
+  --syntax_number: #20a5ba;
+  --syntax_keyword: #c30771;
+  --syntax_atom: #10a778;
+  --syntax_string: #008ec4;
+  --syntax_error: #ffbedc;
+  --syntax_unknown_variable: #838383;
+  --syntax_known_variable: #005f87;
+  --syntax_matchbracket: #20bbfc;
+  --syntax_key: #6636b4;
+  --selection: #d7d4f0;
+  --mono_fonts: 14px/1.5 Menlo, Consolas, monospace;
+}
+
+.observablehq--expanded,
+.observablehq--collapsed,
+.observablehq--function,
+.observablehq--import,
+.observablehq--string:before,
+.observablehq--string:after,
+.observablehq--gray {
+  color: var(--syntax_normal);
+}
+
+.observablehq--collapsed,
+.observablehq--inspect a {
+  cursor: pointer;
+}
+
+.observablehq--caret {
+  margin-right: 4px;
+  vertical-align: middle;
+}
+
+.observablehq--field {
+  text-indent: -1em;
+  margin-left: 1em;
+}
+
+.observablehq--empty {
+  color: var(--syntax_comment);
+}
+
+a[href],
+.observablehq--keyword,
+.observablehq--blue {
+  color: #3182bd;
+}
+
+.observablehq--forbidden,
+.observablehq--pink {
+  color: #e377c2;
+}
+
+.observablehq--orange {
+  color: #e6550d;
+}
+
+.observablehq--null,
+.observablehq--undefined,
+.observablehq--boolean {
+  color: var(--syntax_atom);
+}
+
+.observablehq--bigint,
+.observablehq--number,
+.observablehq--date,
+.observablehq--regexp,
+.observablehq--symbol,
+.observablehq--green {
+  color: var(--syntax_number);
+}
+
+.observablehq--index,
+.observablehq--key {
+  color: var(--syntax_key);
+}
+
+.observablehq--empty {
+  font-style: oblique;
+}
+
+.observablehq--string,
+.observablehq--purple {
+  color: var(--syntax_string);
+}
+
+/* Note: Tachyons' dark-red */
+.observablehq--error,
+.observablehq--red {
+  color: #e7040f;
+}
+
+.observablehq {
+  position: relative;
+  margin: 17px -10px;
+  min-height: 33px; /* Note: adjusted dynamically! */
+  padding: 0 14px 0 10px;
+  border-left: solid 4px transparent;
+  transition: border-left-color 250ms linear;
+}
+
+.observablehq--inspect {
+  font: var(--mono_fonts);
+  overflow-x: auto;
+  display: block;
+  padding: 6px 0;
+  white-space: pre;
+}
+
+.observablehq--error {
+  border-left-color: #e7040f;
+}
+
+.observablehq--error .observablehq--inspect {
+  word-break: break-all;
+  white-space: pre-wrap;
+}
+
+.observablehq--running,
+.observablehq--changed {
+  border-left-color: hsl(217, 13%, 70%);
+}
+</style>
+ 
+<body class='sans-serif flex flex-column justify-stretch vh-100'>
+<div class='pa4'><div id='inspectorOutput'></div></div>
+<div class='flex flex-column pa4'>
+<div><label class='ttu' for='input'>input (JSON)</label></div>
+<textarea class='code pa2 ba' id='input'>[1, 2, 3]</textarea>
+</div>
+<script type='module'>
+import {Inspector} from "./src/index.js";
+let inspector = new Inspector(inspectorOutput);
+function update() {
+  try {
+    inspector.fulfilled(JSON.parse(input.value));
+  } catch(e) { }
+}
+input.addEventListener('input', update);
+update();
+</script>
+</body>
+</html>

--- a/demo.html
+++ b/demo.html
@@ -131,19 +131,35 @@ a[href],
 <body class='sans-serif flex flex-column justify-stretch vh-100'>
 <div class='pa4'><div id='inspectorOutput'></div></div>
 <div class='flex flex-column pa4'>
-<div><label class='ttu' for='input'>input (JSON)</label></div>
+<div><label class='ttu' for='input'>input (JavaScript)</label></div>
 <textarea class='code pa2 ba' id='input'>[1, 2, 3]</textarea>
+<div id='demos' class='mt4'>
+  <h3>Fixed demos</h3>
+</div>
 </div>
 <script type='module'>
 import {Inspector} from "./src/index.js";
 let inspector = new Inspector(inspectorOutput);
 function update() {
   try {
-    inspector.fulfilled(JSON.parse(input.value));
+    inspector.fulfilled((new Function(`return ${input.value}`))());
   } catch(e) { }
 }
 input.addEventListener('input', update);
 update();
+
+function fixed(input) {
+  (new Inspector(demos.appendChild(document.createElement('div')))).fulfilled(input);
+}
+fixed([1, 2, 3, [2, 3]])
+fixed(function a() {})
+fixed(a => {})
+fixed(function* a() {})
+fixed(new Map([[1, 2]]))
+fixed(new Set([1, 2]))
+fixed({a:2, [Symbol('hi')]: 3})
+fixed(new Uint8Array([1, 2, 3]))
+fixed(new Uint16Array([1, 2, 3]))
 </script>
 </body>
 </html>

--- a/src/collapsed.js
+++ b/src/collapsed.js
@@ -1,8 +1,8 @@
-import {isarray, isindex} from "./array";
-import inspectExpanded from "./expanded";
-import formatSymbol from "./formatSymbol";
-import {inspect, replace} from "./inspect";
-import {isown, symbolsof, tagof, valueof} from "./object";
+import {isarray, isindex} from "./array.js";
+import inspectExpanded from "./expanded.js";
+import formatSymbol from "./formatSymbol.js";
+import {inspect, replace} from "./inspect.js";
+import {isown, symbolsof, tagof, valueof} from "./object.js";
 
 export default function inspectCollapsed(object, shallow) {
   const arrayish = isarray(object);
@@ -36,11 +36,9 @@ export default function inspectCollapsed(object, shallow) {
   const span = document.createElement("span");
   span.className = "observablehq--collapsed";
   const a = span.appendChild(document.createElement("a"));
-  const svg = a.appendChild(document.createElementNS("http://www.w3.org/2000/svg", "svg"));
-  svg.setAttribute("width", 16);
-  svg.setAttribute("height", 16);
-  svg.style.verticalAlign = "middle";
-  svg.innerHTML = "<path d='M12 8l-8 5V3z' fill='currentColor' />";
+  a.innerHTML =`<svg width=8 height=8 class='observablehq--caret'>
+    <path d='M7 4L1 8V0z' fill='currentColor' />
+  </svg>`;
   a.appendChild(document.createTextNode(`${tag}${arrayish ? " [" : " {"}`));
   span.addEventListener("mouseup", function(event) {
     event.stopPropagation();

--- a/src/expanded.js
+++ b/src/expanded.js
@@ -1,9 +1,9 @@
-import dispatch from "./dispatch";
-import {isarray, isindex} from "./array";
-import inspectCollapsed from "./collapsed";
-import formatSymbol from "./formatSymbol";
-import {inspect, replace} from "./inspect";
-import {isown, symbolsof, tagof, valueof} from "./object";
+import dispatch from "./dispatch.js";
+import {isarray, isindex} from "./array.js";
+import inspectCollapsed from "./collapsed.js";
+import formatSymbol from "./formatSymbol.js";
+import {inspect, replace} from "./inspect.js";
+import {isown, symbolsof, tagof, valueof} from "./object.js";
 
 export default function inspectExpanded(object) {
   const arrayish = isarray(object);
@@ -26,11 +26,9 @@ export default function inspectExpanded(object) {
   const span = document.createElement("span");
   span.className = "observablehq--expanded";
   const a = span.appendChild(document.createElement("a"));
-  const svg = a.appendChild(document.createElementNS("http://www.w3.org/2000/svg", "svg"));
-  svg.setAttribute("width", 16);
-  svg.setAttribute("height", 16);
-  svg.style.verticalAlign = "middle";
-  svg.innerHTML = "<path d='M8 12L3 4h10z' fill='currentColor' />";
+  a.innerHTML =`<svg width=8 height=8 class='observablehq--caret'>
+    <path d='M4 7L0 1h8z' fill='currentColor' />
+  </svg>`;
   a.appendChild(document.createTextNode(`${tag}${arrayish ? " [" : " {"}`));
   a.addEventListener("mouseup", function(event) {
     event.stopPropagation();

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
-import dispatch from "./dispatch";
-import {inspect} from "./inspect";
+import dispatch from "./dispatch.js";
+import {inspect} from "./inspect.js";
 
 const LOCATION_MATCH = /\s+\(\d+:\d+\)$/m;
 

--- a/src/inspect.js
+++ b/src/inspect.js
@@ -1,13 +1,13 @@
-import dispatch from "./dispatch";
-import inspectCollapsed from "./collapsed";
-import inspectExpanded from "./expanded";
-import formatDate from "./formatDate";
-import formatError from "./formatError";
-import formatRegExp from "./formatRegExp";
-import formatString from "./formatString";
-import formatSymbol from "./formatSymbol";
-import inspectFunction from "./inspectFunction";
-import {FORBIDDEN} from "./object";
+import dispatch from "./dispatch.js";
+import inspectCollapsed from "./collapsed.js";
+import inspectExpanded from "./expanded.js";
+import formatDate from "./formatDate.js";
+import formatError from "./formatError.js";
+import formatRegExp from "./formatRegExp.js";
+import formatString from "./formatString.js";
+import formatSymbol from "./formatSymbol.js";
+import inspectFunction from "./inspectFunction.js";
+import {FORBIDDEN} from "./object.js";
 
 const {prototype: {toString}} = Object;
 

--- a/test/__snapshots__/inspector.test.js.snap
+++ b/test/__snapshots__/inspector.test.js.snap
@@ -19,14 +19,18 @@ exports[`Inspector .fulfilled(value) 1`] = `
   >
     <a>
       <svg
-        height="16"
-        style="vertical-align: middle;"
-        width="16"
+        class="observablehq--caret"
+        height="8"
+        width="8"
       >
+        
+    
         <path
-          d="M12 8l-8 5V3z"
+          d="M7 4L1 8V0z"
           fill="currentColor"
         />
+        
+  
       </svg>
       Array(3) [
     </a>
@@ -61,14 +65,18 @@ exports[`Inspector .fulfilled(value) 2`] = `
   >
     <a>
       <svg
-        height="16"
-        style="vertical-align: middle;"
-        width="16"
+        class="observablehq--caret"
+        height="8"
+        width="8"
       >
+        
+    
         <path
-          d="M8 12L3 4h10z"
+          d="M4 7L0 1h8z"
           fill="currentColor"
         />
+        
+  
       </svg>
       Array(3) [
     </a>


### PR DESCRIPTION
This tweaks the SVG caret in #18 to a smaller caret that works better with our existing inspector style. It also:

- Simplifies the caret construction a bit by just using innerHTML for the SVG element too
- Adds a `demo.html` page that makes development of notebook-inspector significantly more joyful
- Adds `.js` extensions to imports so that `demo.html` can run with zero fanciness