### PR TITLE
Remove 'bound' from function names in the formatting stage

### DIFF
--- a/src/inspectFunction.js
+++ b/src/inspectFunction.js
@@ -15,7 +15,7 @@ export default function inspectFunction(f) {
     default: type = /^class\b/.test(t) ? TYPE_CLASS : TYPE_FUNCTION; break;
   }
 
-  var functionName = (f.name || "").replace("bound ", "");
+  var functionName = (f.name || "").replace(/^bound /, "");
 
   // A class, possibly named.
   // class Name

--- a/src/inspectFunction.js
+++ b/src/inspectFunction.js
@@ -15,10 +15,12 @@ export default function inspectFunction(f) {
     default: type = /^class\b/.test(t) ? TYPE_CLASS : TYPE_FUNCTION; break;
   }
 
+  var functionName = (f.name || "").replace("bound ", "");
+
   // A class, possibly named.
   // class Name
   if (type === TYPE_CLASS) {
-    return formatFunction(type, f.name || "");
+    return formatFunction(type, functionName);
   }
 
   // An arrow function with a single argument.
@@ -41,11 +43,11 @@ export default function inspectFunction(f) {
   // async function name(…)
   // async function* name(…)
   if (m = /^(?:async\s*)?function(?:\s*\*)?(?:\s*\w+)?\s*\(\s*(\w+(?:\s*,\s*\w+)*)?\s*\)/.exec(t)) {
-    return formatFunction(type, (f.name || "") + (m[1] ? "(" + m[1].replace(/\s*,\s*/g, ", ") + ")" : "()"));
+    return formatFunction(type, functionName + (m[1] ? "(" + m[1].replace(/\s*,\s*/g, ", ") + ")" : "()"));
   }
 
   // Something else, like destructuring, comments or default values.
-  return formatFunction(type, (f.name || "") + "(…)");
+  return formatFunction(type, functionName + "(…)");
 }
 
 function formatFunction(type, name) {

--- a/test/__snapshots__/inspector.test.js.snap
+++ b/test/__snapshots__/inspector.test.js.snap
@@ -95,6 +95,23 @@ exports[`Inspector .fulfilled(function value) 5`] = `
 </div>
 `;
 
+exports[`Inspector .fulfilled(function value) 6`] = `
+<div
+  class="observablehq"
+>
+  <span
+    class="observablehq--function observablehq--inspect"
+  >
+    <span
+      class="observablehq--keyword"
+    >
+      ƒ
+    </span>
+     [not a bound function]()
+  </span>
+</div>
+`;
+
 exports[`Inspector .fulfilled(value) 1`] = `
 <div
   class="observablehq"

--- a/test/__snapshots__/inspector.test.js.snap
+++ b/test/__snapshots__/inspector.test.js.snap
@@ -10,6 +10,91 @@ exports[`Inspector .fulfilled(element) 1`] = `
 </div>
 `;
 
+exports[`Inspector .fulfilled(function value) 1`] = `
+<div
+  class="observablehq"
+>
+  <span
+    class="observablehq--function observablehq--inspect"
+  >
+    <span
+      class="observablehq--keyword"
+    >
+      async ƒ
+    </span>
+     (a)
+  </span>
+</div>
+`;
+
+exports[`Inspector .fulfilled(function value) 2`] = `
+<div
+  class="observablehq"
+>
+  <span
+    class="observablehq--function observablehq--inspect"
+  >
+    <span
+      class="observablehq--keyword"
+    >
+      ƒ*
+    </span>
+     (a)
+  </span>
+</div>
+`;
+
+exports[`Inspector .fulfilled(function value) 3`] = `
+<div
+  class="observablehq"
+>
+  <span
+    class="observablehq--function observablehq--inspect"
+  >
+    <span
+      class="observablehq--keyword"
+    >
+      ƒ
+    </span>
+     (a)
+  </span>
+</div>
+`;
+
+exports[`Inspector .fulfilled(function value) 4`] = `
+<div
+  class="observablehq"
+>
+  <span
+    class="observablehq--function observablehq--inspect"
+  >
+    <span
+      class="observablehq--keyword"
+    >
+      ƒ
+    </span>
+     a()
+  </span>
+</div>
+`;
+
+exports[`Inspector .fulfilled(function value) 5`] = `
+<div
+  class="observablehq"
+>
+  <span
+    class="observablehq--function observablehq--inspect"
+  >
+    <span
+      class="observablehq--keyword"
+    >
+      ƒ
+    </span>
+     a()
+  </span>
+</div>
+`;
+
 exports[`Inspector .fulfilled(value) 1`] = `
 <div
   class="observablehq"

--- a/test/inspector.test.js
+++ b/test/inspector.test.js
@@ -42,6 +42,11 @@ describe("Inspector", () => {
     expect(elem).toMatchSnapshot();
     inspector.fulfilled((function a() {}).bind());
     expect(elem).toMatchSnapshot();
+
+    let sym = Symbol('not a bound function');
+    let obj = { [sym]: function() {} };
+    inspector.fulfilled(obj[sym]); // eslint-disable-line no-unused-vars
+    expect(elem).toMatchSnapshot();
   });
 
   test(".rejected(Error)", () => {

--- a/test/inspector.test.js
+++ b/test/inspector.test.js
@@ -17,7 +17,8 @@ describe("Inspector", () => {
     expect(elem).toMatchSnapshot();
   });
 
-  test(".fulfilled(element)", () => { const span = document.createElement("span");
+  test(".fulfilled(element)", () => {
+    const span = document.createElement("span");
     span.textContent = "Surprise!";
     inspector.fulfilled(span);
     expect(elem).toMatchSnapshot();
@@ -27,6 +28,19 @@ describe("Inspector", () => {
     inspector.fulfilled([1, 2, 3]);
     expect(elem).toMatchSnapshot();
     elem.querySelector("a").dispatchEvent(new MouseEvent("mouseup"));
+    expect(elem).toMatchSnapshot();
+  });
+
+  test(".fulfilled(function value)", () => {
+    inspector.fulfilled(async function(a) {}); // eslint-disable-line no-unused-vars
+    expect(elem).toMatchSnapshot();
+    inspector.fulfilled(function* (a) {}); // eslint-disable-line no-unused-vars
+    expect(elem).toMatchSnapshot();
+    inspector.fulfilled(a => {}); // eslint-disable-line no-unused-vars
+    expect(elem).toMatchSnapshot();
+    inspector.fulfilled(function a() {});
+    expect(elem).toMatchSnapshot();
+    inspector.fulfilled((function a() {}).bind());
     expect(elem).toMatchSnapshot();
   });
 


### PR DESCRIPTION
Fixes #20 - removes the `bound ` prefix from function names.

Reading through this, also discovered another surprising corner:

![2018-06-20 at 1 19 pm](https://user-images.githubusercontent.com/32314/41682419-8833c494-748c-11e8-83aa-2ce0d409fdbc.png)

So I made sure we don't accidentally remove `bound` in any symbol description. As far as the symbol function name... given that it's extraordinarily rare, I think our current behavior is totally fine.