### PR TITLE
Collapse long strings.

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -37,6 +37,21 @@
   vertical-align: middle;
 }
 
+.observablehq--string-expand {
+  margin-left: 6px;
+  padding: 2px 6px;
+  border-radius: 2px;
+  font-size: 80%;
+  background: #eee;
+  color: #888;
+  cursor: pointer;
+  vertical-align: middle;
+}
+
+.observablehq--string-expand:hover {
+  color: #222;
+}
+
 .observablehq--field {
   text-indent: -1em;
   margin-left: 1em;
@@ -160,6 +175,11 @@ fixed(new Set([1, 2]))
 fixed({a:2, [Symbol('hi')]: 3})
 fixed(new Uint8Array([1, 2, 3]))
 fixed(new Uint16Array([1, 2, 3]))
+fixed("A short string")
+fixed({objProp: "A short string"})
+fixed(["A short string"])
+fixed(Array.from({ length: 1000 }, (_, i) => `hi ${i}`).join('\n'))
+fixed({obProp: Array.from({ length: 1000 }, (_, i) => `hi ${i}`).join('\n')})
 </script>
 </body>
 </html>

--- a/src/formatString.js
+++ b/src/formatString.js
@@ -1,13 +1,48 @@
-/* eslint-disable no-control-regex */
+import {inspect, replace} from "./inspect.js";
 
-export default function formatString(string, full) {
-  if (full) return (count(string, /["\n]/g) <= count(string, /`|\${/g) ? JSON.stringify : templatify)(string);
-  if (string.length > 100) string = `${string.slice(0, 50)}…${string.slice(-49)}`;
-  return JSON.stringify(string);
+/* eslint-disable no-control-regex */
+const NEWLINE_LIMIT = 20;
+
+export default function formatString(string, full, expanded) {
+  if (full && count(string, /["\n]/g) <= count(string, /`|\${/g)) {
+    const span = document.createElement("span");
+    span.className = "observablehq--string";
+    span.textContent = JSON.stringify(string);
+    return span;
+  }
+
+  if (full) {
+    const lines = string.split('\n');
+    if (lines.length > NEWLINE_LIMIT && !expanded) {
+      const div = document.createElement("div");
+      const span = div.appendChild(document.createElement('span'));
+      const splitter = div.appendChild(document.createElement('span'));
+      const truncatedCount = lines.length - NEWLINE_LIMIT;
+      splitter.textContent = `Show ${truncatedCount} truncated line${truncatedCount > 1 ? 's': ''}`;
+      splitter.className = "observablehq--string-expand";
+      splitter.addEventListener("mouseup", function (event) {
+        event.stopPropagation();
+        replace(div, inspect(string, !full, true));
+      });
+      span.className = "observablehq--string";
+      span.textContent = "`" + lines.slice(0, NEWLINE_LIMIT).join('\n');
+      return div;
+    }
+    const span = document.createElement("span");
+    span.className = "observablehq--string";
+    span.textContent = "`" + templatify(string) + "`";
+    return span;
+  }
+
+  const span = document.createElement("span");
+  span.className = "observablehq--string";
+  span.textContent = JSON.stringify(string.length > 100 ?
+    `${string.slice(0, 50)}…${string.slice(-49)}` : string);
+  return span;
 }
 
 function templatify(string) {
-  return "`" + string.replace(/[\\`\x00-\x09\x0b-\x19]|\${/g, templatifyChar) + "`";
+  return string.replace(/[\\`\x00-\x09\x0b-\x19]|\${/g, templatifyChar);
 }
 
 function templatifyChar(char) {

--- a/src/inspect.js
+++ b/src/inspect.js
@@ -18,9 +18,9 @@ export function inspect(value, shallow, expand) {
     case "undefined": { value += ""; break; }
     case "number": { value = value === 0 && 1 / value < 0 ? "-0" : value + ""; break; }
     case "bigint": { value = value + "n"; break; }
-    case "string": { value = formatString(value, shallow === false); break; }
     case "symbol": { value = formatSymbol(value); break; }
     case "function": { return inspectFunction(value); }
+    case "string": { return formatString(value, shallow === false, expand); }
     default: {
       if (value === null) { type = null, value = "null"; break; }
       if (value instanceof Date) { type = "date", value = formatDate(value); break; }

--- a/test/__snapshots__/inspector.test.js.snap
+++ b/test/__snapshots__/inspector.test.js.snap
@@ -246,3 +246,45 @@ hi
   </div>
 </div>
 `;
+
+exports[`into truncates a string with > 20 newlines 2`] = `
+<div>
+  <div
+    class="observablehq"
+  >
+    <div
+      class="observablehq--inspect"
+    >
+      <span
+        class="observablehq--string"
+      >
+        \`hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+      </span>
+      <span
+        class="observablehq--string-expand"
+      >
+        Show 1 truncated line
+      </span>
+    </div>
+  </div>
+</div>
+`;

--- a/test/__snapshots__/inspector.test.js.snap
+++ b/test/__snapshots__/inspector.test.js.snap
@@ -154,6 +154,43 @@ exports[`Inspector initial state 1`] = `
 />
 `;
 
+exports[`into formats a string with JSON syntax if it doesn’t have many newlines 1`] = `
+<div>
+  <div
+    class="observablehq"
+  >
+    <span
+      class="observablehq--string observablehq--inspect"
+    >
+      "hi hi hi hi hi hi hi hi hi hi"
+    </span>
+  </div>
+</div>
+`;
+
+exports[`into formats a string with template syntax if it has multiple newlines 1`] = `
+<div>
+  <div
+    class="observablehq"
+  >
+    <span
+      class="observablehq--string observablehq--inspect"
+    >
+      \`hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi\`
+    </span>
+  </div>
+</div>
+`;
+
 exports[`into into(div) 1`] = `
 <div>
   <div
@@ -164,6 +201,48 @@ exports[`into into(div) 1`] = `
     >
       42
     </span>
+  </div>
+</div>
+`;
+
+exports[`into truncates a string with > 20 newlines 1`] = `
+<div>
+  <div
+    class="observablehq"
+  >
+    <div
+      class="observablehq--inspect"
+    >
+      <span
+        class="observablehq--string"
+      >
+        \`hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+      </span>
+      <span
+        class="observablehq--string-expand"
+      >
+        Show 10 truncated lines
+      </span>
+    </div>
   </div>
 </div>
 `;

--- a/test/__snapshots__/inspector.test.js.snap
+++ b/test/__snapshots__/inspector.test.js.snap
@@ -252,6 +252,49 @@ exports[`into truncates a string with > 20 newlines 2`] = `
   <div
     class="observablehq"
   >
+    <span
+      class="observablehq--string observablehq--inspect"
+    >
+      \`hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi
+hi\`
+    </span>
+  </div>
+</div>
+`;
+
+exports[`into truncates a string with > 20 newlines 3`] = `
+<div>
+  <div
+    class="observablehq"
+  >
     <div
       class="observablehq--inspect"
     >

--- a/test/inspector.test.js
+++ b/test/inspector.test.js
@@ -49,4 +49,25 @@ describe("into", () => {
     inspector.fulfilled(42);
     expect(container).toMatchSnapshot();
   });
+
+  test("formats a string with template syntax if it has multiple newlines", () => {
+    const container = document.createElement("div");
+    const inspector = Inspector.into(container)();
+    inspector.fulfilled(Array.from({ length: 10 }, () => 'hi').join('\n'));
+    expect(container).toMatchSnapshot();
+  });
+
+  test("formats a string with JSON syntax if it doesn’t have many newlines", () => {
+    const container = document.createElement("div");
+    const inspector = Inspector.into(container)();
+    inspector.fulfilled(Array.from({ length: 10 }, () => 'hi').join(' '));
+    expect(container).toMatchSnapshot();
+  });
+
+  test("truncates a string with > 20 newlines", () => {
+    const container = document.createElement("div");
+    const inspector = Inspector.into(container)();
+    inspector.fulfilled(Array.from({ length: 30 }, () => 'hi').join('\n'));
+    expect(container).toMatchSnapshot();
+  });
 });

--- a/test/inspector.test.js
+++ b/test/inspector.test.js
@@ -69,6 +69,8 @@ describe("into", () => {
     const inspector = Inspector.into(container)();
     inspector.fulfilled(Array.from({ length: 30 }, () => 'hi').join('\n'));
     expect(container).toMatchSnapshot();
+    container.querySelector(".observablehq--string-expand").dispatchEvent(new MouseEvent("mouseup"));
+    expect(container).toMatchSnapshot();
   });
 
   test("truncates a string with > 20 newlines", () => {

--- a/test/inspector.test.js
+++ b/test/inspector.test.js
@@ -70,4 +70,11 @@ describe("into", () => {
     inspector.fulfilled(Array.from({ length: 30 }, () => 'hi').join('\n'));
     expect(container).toMatchSnapshot();
   });
+
+  test("truncates a string with > 20 newlines", () => {
+    const container = document.createElement("div");
+    const inspector = Inspector.into(container)();
+    inspector.fulfilled(Array.from({ length: 21 }, () => 'hi').join('\n'));
+    expect(container).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/32314/44493767-24b6f580-a61e-11e8-9caf-31aa4a5dcd76.png)

Allows long, top-level strings to be expanded or collapsed. Fixes #24